### PR TITLE
feat(feign-client): implement a http client request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Spring Boot Example Repository
+
+This repository contains a bunch of examples of how to deal with common 
+technical challenges, which developers face frequently, when implementing services 
+with SpringBoot.
+
+The project structure is oriented to domain driven design (DDD) and clean architecture.
+However, the primary purpose of this repository is to serve continuing education, and 
+therefore the architectural concepts are not consistently followed.
+
+## Tools, Frameworks & Conventions
+
+### Spring
+
+#### HTTP Clients
+
+##### REST Clients
+
+* [Feign - Declarative REST Client](https://cloud.spring.io/spring-cloud-netflix/multi/multi_spring-cloud-feign.html)
+
+### Testing Tools
+
+#### Unit Tests
+
+Unit Tests follow the naming pattern "<TestName>Test". 
+
+* [JUnit5](https://junit.org/junit5/docs/current/user-guide/)
+* [AssertJ](https://assertj.github.io/doc/) 
+  * used to write fluent assertions
+* [Mockito](https://site.mockito.org/)
+  * used to mock dependencies to other services 
+
+#### Integration Tests
+
+Integration Tests follow the naming pattern "<TestName>IT". An integration test scenario is created with tools, which 
+can be easily integrated into JUnit & SpringBoot.
+
+* [WireMock](https://wiremock.org/) 
+  * used to test outgoing http requests 
+* [Testcontainers](https://www.testcontainers.org/) 
+  * used to start any type of external services, i.e. databases or message queues.  

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation project(':infrastructure-petstore-rest-client')
     implementation project(':domain')
 
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/application/src/main/java/today/stepbeyond/examples/springbootexamples/infrastructure/repository/impl/KeyValueInMemoryRepository.java
+++ b/application/src/main/java/today/stepbeyond/examples/springbootexamples/infrastructure/repository/impl/KeyValueInMemoryRepository.java
@@ -22,14 +22,22 @@ public class KeyValueInMemoryRepository implements PetRepository {
     }
 
     @Override
-    public UUID create(Pet pet) {
+    public Pet create(Pet pet) {
         if (store.containsKey(pet.getId())) {
             throw new IllegalArgumentException("Pet already exists");
         } else {
             var newPet = createNewPet(pet);
             store.put(newPet.getId(), newPet);
-            return newPet.getId();
+            return newPet;
         }
+    }
+
+    @Override
+    public Pet update(Pet pet) {
+        if (pet.getId() == null || !store.containsKey(pet.getId())) {
+            throw new IllegalArgumentException("Pet cannot be updated");
+        }
+        return store.put(pet.getId(), pet);
     }
 
     private static Pet createNewPet(Pet pet) {

--- a/application/src/main/resources/application.properties
+++ b/application/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+petStoreApi.url=http://localhost:9000

--- a/application/src/test/java/today/stepbeyond/examples/springbootexamples/infrastructure/repository/KeyValueInMemoryRepositoryTest.java
+++ b/application/src/test/java/today/stepbeyond/examples/springbootexamples/infrastructure/repository/KeyValueInMemoryRepositoryTest.java
@@ -24,10 +24,10 @@ class KeyValueInMemoryRepositoryTest {
     void shouldNotCreateAlreadyExistingDog() {
         // GIVEN
         var pet = new Dog().setName("Hasso");
-        var uuidOfDog = objectUnderTest.create(pet);
+        var dog = objectUnderTest.create(pet);
 
         // WHEN, THEN
-        assertThatCode(() -> objectUnderTest.create(pet.setId(uuidOfDog)))
+        assertThatCode(() -> objectUnderTest.create(dog))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -37,8 +37,8 @@ class KeyValueInMemoryRepositoryTest {
         var pet = new Dog().setName("Hasso");
 
         // WHEN
-        var uuidOfDog = objectUnderTest.create(pet);
-        var foundDog = objectUnderTest.find(uuidOfDog);
+        var dog = objectUnderTest.create(pet);
+        var foundDog = objectUnderTest.find(dog.getId());
 
         // THEN
         assertThat(foundDog)

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '2.7.8'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
 
@@ -12,7 +11,7 @@ repositories {
 }
 
 subprojects {
-	apply plugin: 'java'
+	apply plugin: 'java-library'
 	apply plugin: 'io.spring.dependency-management'
 
 	group = 'today.stepbeyond.examples'
@@ -29,6 +28,7 @@ subprojects {
 	dependencyManagement {
 		imports {
 			mavenBom("org.springframework.boot:spring-boot-dependencies:2.7.8")
+			mavenBom("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
 		}
 	}
 }

--- a/domain/src/main/java/today/stepbeyond/examples/springbootexamples/domain/DogDomainService.java
+++ b/domain/src/main/java/today/stepbeyond/examples/springbootexamples/domain/DogDomainService.java
@@ -7,6 +7,15 @@ import today.stepbeyond.examples.springbootexamples.domain.model.Dog;
 public class DogDomainService {
 
     public Dog createDog(String name) {
-        return new Dog().setName(name);
+        return new Dog()
+                .setName(name)
+                .setRegistered(false);
+    }
+
+    public Dog registerDog(Dog dog) {
+        return new Dog()
+                .setId(dog.getId())
+                .setName(dog.getName())
+                .setRegistered(true);
     }
 }

--- a/domain/src/main/java/today/stepbeyond/examples/springbootexamples/domain/model/Dog.java
+++ b/domain/src/main/java/today/stepbeyond/examples/springbootexamples/domain/model/Dog.java
@@ -3,10 +3,10 @@ package today.stepbeyond.examples.springbootexamples.domain.model;
 import java.util.UUID;
 
 public class Dog implements Pet {
-
     private String name;
-
     private UUID id;
+
+    private boolean registered;
 
     @Override
     public String getName() {
@@ -30,6 +30,15 @@ public class Dog implements Pet {
 
     public Dog setId(UUID id) {
         this.id = id;
+        return this;
+    }
+
+    public boolean isRegistered() {
+        return registered;
+    }
+
+    public Dog setRegistered(boolean registered) {
+        this.registered = registered;
         return this;
     }
 }

--- a/domain/src/main/java/today/stepbeyond/examples/springbootexamples/infrastructure/gateways/PetStoreClient.java
+++ b/domain/src/main/java/today/stepbeyond/examples/springbootexamples/infrastructure/gateways/PetStoreClient.java
@@ -1,0 +1,8 @@
+package today.stepbeyond.examples.springbootexamples.infrastructure.gateways;
+
+import today.stepbeyond.examples.springbootexamples.domain.model.Pet;
+
+public interface PetStoreClient {
+
+    boolean registerPet(Pet pet);
+}

--- a/domain/src/main/java/today/stepbeyond/examples/springbootexamples/infrastructure/repository/PetRepository.java
+++ b/domain/src/main/java/today/stepbeyond/examples/springbootexamples/infrastructure/repository/PetRepository.java
@@ -8,5 +8,7 @@ public interface PetRepository {
 
     Optional<Pet> find(UUID id);
 
-    UUID create(Pet newBornDog);
+    Pet create(Pet dog);
+
+    Pet update(Pet dog);
 }

--- a/domain/src/main/java/today/stepbeyond/examples/springbootexamples/usecases/DogUseCases.java
+++ b/domain/src/main/java/today/stepbeyond/examples/springbootexamples/usecases/DogUseCases.java
@@ -3,22 +3,32 @@ package today.stepbeyond.examples.springbootexamples.usecases;
 import org.springframework.stereotype.Service;
 import today.stepbeyond.examples.springbootexamples.domain.DogDomainService;
 import today.stepbeyond.examples.springbootexamples.domain.model.Dog;
+import today.stepbeyond.examples.springbootexamples.infrastructure.gateways.PetStoreClient;
 import today.stepbeyond.examples.springbootexamples.infrastructure.repository.PetRepository;
 
 @Service
 public class DogUseCases implements BirthOfADog {
     private final DogDomainService dogDomainService;
+
     private final PetRepository petRepository;
 
-    public DogUseCases(DogDomainService dogDomainService, PetRepository petRepository) {
+    private final PetStoreClient petStoreClient;
+
+    public DogUseCases(DogDomainService dogDomainService, PetRepository petRepository, PetStoreClient petStoreClient) {
         this.dogDomainService = dogDomainService;
         this.petRepository = petRepository;
+        this.petStoreClient = petStoreClient;
     }
 
     @Override
     public Dog birthOfADog(String name) {
         var newBornDog = dogDomainService.createDog(name);
-        var id = petRepository.create(newBornDog);
-        return newBornDog.setId(id);
+        newBornDog = (Dog) petRepository.create(newBornDog);
+        if (petStoreClient.registerPet(newBornDog)) {
+            var registeredDog = dogDomainService.registerDog(newBornDog);
+            petRepository.update(registeredDog);
+            return registeredDog;
+        }
+        return newBornDog;
     }
 }

--- a/domain/src/test/java/today/stepbeyond/examples/springbootexamples/domain/DogDomainServiceTest.java
+++ b/domain/src/test/java/today/stepbeyond/examples/springbootexamples/domain/DogDomainServiceTest.java
@@ -1,0 +1,43 @@
+package today.stepbeyond.examples.springbootexamples.domain;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import today.stepbeyond.examples.springbootexamples.domain.model.Dog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DogDomainServiceTest {
+
+    DogDomainService objectUnderTest = new DogDomainService();
+
+    @Test
+    void shouldCreateDog() {
+        // GIVEN
+        var name = "Hasso";
+
+        // WHEN
+        var result = objectUnderTest.createDog(name);
+
+        // THEN
+        assertThat(result)
+                .extracting(Dog::getName, Dog::isRegistered, Dog::getId)
+                .contains("Hasso", false, null);
+    }
+
+    @Test
+    void shouldRegisterDog() {
+        // GIVEN
+        var dog = new Dog()
+                .setName("Hasso")
+                .setId(UUID.fromString("9AD0236E-43A7-40C7-9FF1-54FEE4D23D84"))
+                .setRegistered(false);
+
+        // WHEN
+        var result = objectUnderTest.registerDog(dog);
+
+        // THEN
+        assertThat(result)
+                .extracting(Dog::getName, Dog::isRegistered, Dog::getId)
+                .contains("Hasso", true, UUID.fromString("9AD0236E-43A7-40C7-9FF1-54FEE4D23D84"));
+    }
+}

--- a/domain/src/test/java/today/stepbeyond/examples/springbootexamples/usecases/DogUseCasesTest.java
+++ b/domain/src/test/java/today/stepbeyond/examples/springbootexamples/usecases/DogUseCasesTest.java
@@ -5,10 +5,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import today.stepbeyond.examples.springbootexamples.domain.DogDomainService;
 import today.stepbeyond.examples.springbootexamples.domain.model.Dog;
 import today.stepbeyond.examples.springbootexamples.domain.model.PetType;
+import today.stepbeyond.examples.springbootexamples.infrastructure.gateways.PetStoreClient;
 import today.stepbeyond.examples.springbootexamples.infrastructure.repository.PetRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,11 +22,14 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class DogUseCasesTest {
 
-    @Mock
+    @Spy
     DogDomainService dogDomainService;
 
     @Mock
     PetRepository petRepository;
+
+    @Mock
+    PetStoreClient petStoreClient;
 
     @InjectMocks
     DogUseCases objectUnderTest;
@@ -35,19 +40,29 @@ class DogUseCasesTest {
         var dogName = "Hasso";
         var id = UUID.fromString("DF08B211-4D02-4FC1-910C-5803F1E42BD6");
         var dog = new Dog().setName(dogName).setId(id);
-        when(dogDomainService.createDog(dogName))
-                .thenReturn(dog);
-        when(petRepository.create(dog))
-                .thenReturn(id);
+        when(petStoreClient.registerPet(any()))
+                .thenReturn(true);
+        when(petRepository.create(any()))
+                .thenReturn(new Dog()
+                        .setName(dogName)
+                        .setRegistered(false)
+                        .setId(id));
+        when(petRepository.update(any()))
+                .thenReturn(new Dog()
+                        .setName(dogName)
+                        .setRegistered(true)
+                        .setId(id));
 
         // WHEN
         var newDog = objectUnderTest.birthOfADog(dogName);
 
         // THEN
         assertThat(newDog)
-                .extracting(Dog::getName, Dog::getType)
-                .contains("Hasso", PetType.DOG);
+                .extracting(Dog::getName, Dog::getType, Dog::isRegistered)
+                .contains("Hasso", PetType.DOG, true);
         verify(dogDomainService, times(1)).createDog(any());
         verify(petRepository, times(1)).create(any());
+        verify(petRepository, times(1)).update(any());
+        verify(petStoreClient, times(1)).registerPet(any());
     }
 }

--- a/infrastructure-petstore-rest-client/build.gradle
+++ b/infrastructure-petstore-rest-client/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+    api 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation project(':domain')
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock'
+}

--- a/infrastructure-petstore-rest-client/src/main/java/today/stepbeyond/examples/springbootexamples/infrastructure/gateways/PetStoreRestClient.java
+++ b/infrastructure-petstore-rest-client/src/main/java/today/stepbeyond/examples/springbootexamples/infrastructure/gateways/PetStoreRestClient.java
@@ -1,0 +1,32 @@
+package today.stepbeyond.examples.springbootexamples.infrastructure.gateways;
+
+import feign.FeignException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import today.stepbeyond.examples.springbootexamples.domain.model.Pet;
+import today.stepbeyond.examples.springbootexamples.infrastructure.gateways.api.PetStoreApi;
+import today.stepbeyond.examples.springbootexamples.infrastructure.gateways.api.model.RegistrationRequest;
+
+@Service
+public class PetStoreRestClient implements PetStoreClient {
+
+    Logger log = LoggerFactory.getLogger(PetStoreRestClient.class);
+
+    private final PetStoreApi api;
+
+    public PetStoreRestClient(PetStoreApi api) {
+        this.api = api;
+    }
+
+    @Override
+    public boolean registerPet(Pet pet) {
+        try {
+            var registrationResponse = api.registerPet(new RegistrationRequest().setPetId(pet.getId()));
+            return registrationResponse.getStatusCode().is2xxSuccessful();
+        } catch (FeignException.FeignClientException e) {
+            log.info("Unable to register pet in petstore service", e);
+            return false;
+        }
+    }
+}

--- a/infrastructure-petstore-rest-client/src/main/java/today/stepbeyond/examples/springbootexamples/infrastructure/gateways/api/PetStoreApi.java
+++ b/infrastructure-petstore-rest-client/src/main/java/today/stepbeyond/examples/springbootexamples/infrastructure/gateways/api/PetStoreApi.java
@@ -1,0 +1,18 @@
+package today.stepbeyond.examples.springbootexamples.infrastructure.gateways.api;
+
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import today.stepbeyond.examples.springbootexamples.infrastructure.gateways.api.model.RegistrationRequest;
+
+@FeignClient(name = "petStoreApi", url = "${petStoreApi.url}")
+public interface PetStoreApi {
+
+    @PostMapping(
+            path = "registrations",
+            produces = MediaType.APPLICATION_JSON_VALUE,
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<Void> registerPet(RegistrationRequest registrationRequest);
+}

--- a/infrastructure-petstore-rest-client/src/main/java/today/stepbeyond/examples/springbootexamples/infrastructure/gateways/api/model/RegistrationRequest.java
+++ b/infrastructure-petstore-rest-client/src/main/java/today/stepbeyond/examples/springbootexamples/infrastructure/gateways/api/model/RegistrationRequest.java
@@ -1,0 +1,17 @@
+package today.stepbeyond.examples.springbootexamples.infrastructure.gateways.api.model;
+
+import java.util.UUID;
+
+public class RegistrationRequest {
+
+    private UUID petId;
+
+    public UUID getPetId() {
+        return petId;
+    }
+
+    public RegistrationRequest setPetId(UUID petId) {
+        this.petId = petId;
+        return this;
+    }
+}

--- a/infrastructure-petstore-rest-client/src/test/java/today/stepbeyond/examples/springbootexamples/infrastructure/gateways/PetStoreRestClientIT.java
+++ b/infrastructure-petstore-rest-client/src/test/java/today/stepbeyond/examples/springbootexamples/infrastructure/gateways/PetStoreRestClientIT.java
@@ -1,0 +1,72 @@
+package today.stepbeyond.examples.springbootexamples.infrastructure.gateways;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import today.stepbeyond.examples.springbootexamples.domain.model.Dog;
+import wiremock.org.eclipse.jetty.http.HttpHeader;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.created;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(
+        properties = "petStoreApi.url=http://localhost:${wiremock.server.port}/",
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@AutoConfigureWireMock(port = 0)
+class PetStoreRestClientIT {
+
+    @Autowired
+    private PetStoreRestClient objectUnderTest;
+
+    @BeforeEach
+    void setUp() {
+        WireMock.reset();
+    }
+
+    @Test
+    void shouldRegisterDog() {
+        // GIVEN
+        var uuid = UUID.fromString("66d0d3c4-7f78-4106-84ad-71691ba6d7d6");
+        var dog = new Dog()
+                .setName("Hasso")
+                .setId(uuid)
+                .setRegistered(false);
+
+        WireMock.stubFor(post("/registrations").withRequestBody(equalTo("{\"petId\":\"66d0d3c4-7f78-4106-84ad-71691ba6d7d6\"}"))
+                .willReturn(
+                        created().withHeader(HttpHeader.LOCATION.asString(), UUID.randomUUID().toString())));
+
+        // WHEN
+        var result = objectUnderTest.registerPet(dog);
+
+        // THEN
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldNotRegisterDog() {
+        // GIVEN
+        var uuid = UUID.fromString("66d0d3c4-7f78-4106-84ad-71691ba6d7d6");
+        var dog = new Dog()
+                .setName("Hasso")
+                .setId(uuid)
+                .setRegistered(false);
+
+        WireMock.stubFor(post("/registrations").withRequestBody(equalTo("{\"petId\":\"66d0d3c4-7f78-4106-84ad-71691ba6d7d6\"}"))
+                .willReturn(ResponseDefinitionBuilder.responseDefinition().withStatus(422)));
+
+        // WHEN
+        var result = objectUnderTest.registerPet(dog);
+
+        // THEN
+        assertThat(result).isFalse();
+    }
+}

--- a/infrastructure-petstore-rest-client/src/test/java/today/stepbeyond/examples/springbootexamples/infrastructure/gateways/PetStoreRestClientTest.java
+++ b/infrastructure-petstore-rest-client/src/test/java/today/stepbeyond/examples/springbootexamples/infrastructure/gateways/PetStoreRestClientTest.java
@@ -1,0 +1,40 @@
+package today.stepbeyond.examples.springbootexamples.infrastructure.gateways;
+
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import today.stepbeyond.examples.springbootexamples.infrastructure.gateways.api.PetStoreApi;
+import today.stepbeyond.examples.springbootexamples.domain.model.Dog;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PetStoreRestClientTest {
+
+    @Mock
+    PetStoreApi api;
+
+    @InjectMocks
+    PetStoreRestClient objectUnderTest;
+
+    @Test
+    void shouldRegisterPet() {
+        // GIVEN
+        var dog = new Dog().setName("Hasso")
+                .setRegistered(false)
+                .setId(UUID.fromString("9AD0236E-43A7-40C7-9FF1-54FEE4D23D84"));
+        when(api.registerPet(any())).thenReturn(ResponseEntity.ok(null));
+
+        // WHEN
+        var result = objectUnderTest.registerPet(dog);
+
+        // THEN
+        assertThat(result).isTrue();
+    }
+}

--- a/infrastructure-petstore-rest-client/src/test/java/today/stepbeyond/examples/springbootexamples/infrastructure/gateways/Testapp.java
+++ b/infrastructure-petstore-rest-client/src/test/java/today/stepbeyond/examples/springbootexamples/infrastructure/gateways/Testapp.java
@@ -1,4 +1,4 @@
-package today.stepbeyond.examples.springbootexamples;
+package today.stepbeyond.examples.springbootexamples.infrastructure.gateways;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -6,9 +6,9 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @EnableFeignClients
-public class SpringBootExamplesApplication {
+public class Testapp {
 
-	public static void main(String[] args) {
-		SpringApplication.run(SpringBootExamplesApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(Testapp.class, args);
+    }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,4 +2,5 @@ rootProject.name = 'spring-boot-examples'
 
 include 'domain'
 include 'application'
+include 'infrastructure-petstore-rest-client'
 


### PR DESCRIPTION
... therefore some changes had to be implemented:
(1) - The `newBornDog` UseCase was enhanced with a registration process, which requires a call to a service outside the domain 
(2) - A new infrastructure submodule, which implements a REST call to another service 
(3) - The integration is tested with WireMock